### PR TITLE
More mitigation for CVE-2021-44228

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN yum update -y
 
 # https://nvd.nist.gov/vuln/detail/CVE-2021-44228
 # Can be removed when 366 is released
-RUN rm -rf /lib/trino/plugin/elasticsearch
+RUN rm -rf /lib/trino/plugin/elasticsearch && rm -rf /lib/trino/plugin/accumulo
 
 USER trino:trino
 # Add Db2 connector


### PR DESCRIPTION
Accumulo plugin has: `usr/lib/trino/plugin/accumulo/log4j-1.2.17.jar`