### PR TITLE
Remove trino-event-stream plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,4 @@ RUN rm -rf /lib/trino/plugin/elasticsearch && rm -rf /lib/trino/plugin/accumulo 
 USER trino:trino
 # Add Db2 connector
 COPY --from=builder --chown=trino:trino trino-db2-* /usr/lib/trino/plugin/db2
-COPY --from=builder --chown=trino:trino trino-event-* /usr/lib/trino/plugin/trino-event-stream
 COPY run-trino.sh /usr/lib/trino/bin/run-trino

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,6 @@ RUN apt update && \
 RUN wget -c https://github.com/IBM/trino-db2/releases/download/${TRINO_VERSION}/trino-db2-${TRINO_VERSION}.zip
 RUN unzip trino-db2-$TRINO_VERSION.zip && rm -f trino-db2-$TRINO_VERSION.zip
 
-RUN wget -c https://github.com/IBM/trino-event-stream/releases/download/${TRINO_VERSION}/trino-event-stream-${TRINO_VERSION}.zip
-RUN unzip trino-event-stream-${TRINO_VERSION}.zip && rm -f trino-event-stream-${TRINO_VERSION}.zip
-
 # Consume historial image from Trino
 FROM trinodb/trino:$TRINO_VERSION
 

--- a/README.md
+++ b/README.md
@@ -41,20 +41,6 @@ Then:
 docker run -d -p 8080:8080 -v /foo/bar/db2.properties:/usr/lib/trino/default/etc/catalog/db2.properties:ro shawnzhu/trino:latest
 ```
 
-### Trino Event Streams
-
-Given configuration of Trino Event Streams:
-
-```
-# cat event-listener.properties
-event-listener.name=event-stream
-bootstrap.servers=broker:9092
-key.serializer=org.apache.kafka.common.serialization.StringSerializer
-value.serializer=org.apache.kafka.common.serialization.StringSerializer
-```
-
-All Trino queries info will be sent to topic `trino.event`. 
-
 ## Features
 
 ### Graceful Shutdown

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Actions Status](https://github.com/IBM/docker-prestodb/workflows/test/badge.svg)](https://github.com/IBM/docker-prestodb/actions)
 [![Docker Build Statu](https://img.shields.io/docker/build/shawnzhu/prestodb.svg)](https://hub.docker.com/r/shawnzhu/prestodb/)
 
-This is a docker image for [Trino](https://trino.io/) with [Db2 connector](https://github.com/IBM/trino-db2/) and [trino-event-stream](https://github.com/IBM/trino-event-stream).
+This is a docker image for [Trino](https://trino.io/) with [Db2 connector](https://github.com/IBM/trino-db2/).
 
 **Notice**: it starts to switch the base image from openjdk to the official trino container image [`trinodb/trino`](https://hub.docker.com/r/trinodb/trino) since tag `354`.
 

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -13,10 +13,6 @@ fileExistenceTests:
   gid: 1000
 - name: trino-db2-*.jar
   path: /usr/lib/trino/plugin/db2/
-- name: trino-event-stream-*.jar 
-  path: /usr/lib/trino/plugin/trino-event-stream
-  uid: 1000
-  gid: 1000
 metadataTest:
   env:
   - key: JAVA_HOME


### PR DESCRIPTION
Removing unused plugin to simplify patching.

Supports whitewater-analytics/discuss#2819