### PR TITLE
Update expected permissions

### DIFF
--- a/test_config.yaml
+++ b/test_config.yaml
@@ -6,7 +6,7 @@ fileExistenceTests:
   gid: 1000
 - name: run-trino
   path: /usr/lib/trino/bin/run-trino
-  permissions: '-rwxr-xr-x'
+  permissions: '-rwxrwxr-x'
 - name: trino-connector-db2
   path: /usr/lib/trino/plugin/db2
   uid: 1000


### PR DESCRIPTION
I was seeing the following error in Travis:

```
Error: /usr/lib/trino/bin/run-trino has incorrect permissions. Expected: -rwxr-xr-x, Actual: -rwxrwxr-x
```

This change should allow the test to pass.