### PR TITLE
Update test_config.yaml

### DIFF
--- a/test_config.yaml
+++ b/test_config.yaml
@@ -18,7 +18,7 @@ fileExistenceTests:
   uid: 1000
   gid: 1000
 metadataTest:
-  env:
+  envVars:
   - key: JAVA_HOME
     value: /usr/lib/jvm/zulu17
   exposedPorts: ["8080"]


### PR DESCRIPTION
It appears that the correct formatting is `envVars`, not `env`. This would explain the error we are getting in our builds.

`field env not found in type v2.MetadataTest`

https://github.com/GoogleContainerTools/container-structure-test#metadata-test

Supports https://github.ibm.com/whitewater-analytics/discuss/issues/2908